### PR TITLE
Revised repo clone CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ directory:
 
     ```shell
     $ cd Packages
-    $ git clone git@github.com:gavinaiken/bbedit-scripts.git markdown-github.bbpackage
+    $ git clone https://github.com/gavinaiken/bbedit-scripts.git markdown-github.bbpackage
     ```
 
 4. Optionally, if you want to make the Github Flavored Markdown preview style the default


### PR DESCRIPTION
Previous command generated "Permission denied (publickey)" permission errors. GitHub documentation suggests this is the preferred approach and it worked for me.

https://help.github.com/articles/cloning-a-repository/
