### PR TITLE
Fix shebang line

### DIFF
--- a/Contents/Preview Filters/DefaultFilter_Markdown.rb
+++ b/Contents/Preview Filters/DefaultFilter_Markdown.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rubygems'
 require 'redcarpet'
 
 r = Redcarpet::Markdown.new(Redcarpet::Render::HTML, 

--- a/Contents/Preview Filters/DefaultFilter_Markdown.rb
+++ b/Contents/Preview Filters/DefaultFilter_Markdown.rb
@@ -1,4 +1,4 @@
-#!/usr/local/var/rbenv/versions/2.1.2/bin/ruby
+#!/usr/bin/env ruby
 
 require 'rubygems'
 require 'redcarpet'


### PR DESCRIPTION
This PR modifies the shebang line to find an appropriate ruby binary from the $PATH, and removes a hardcoded reference to rubygems.

Thanks, your project saved me some time in previewing GFM tables from BBEdit. 