### PR TITLE
Syntax highlighting

### DIFF
--- a/Contents/Preview CSS/DefaultCSS_Markdown.css
+++ b/Contents/Preview CSS/DefaultCSS_Markdown.css
@@ -139,3 +139,93 @@ table th, table td {
 table th {
   font-weight: bold;
 }
+
+/* Syntax Highlighting */
+
+.highlight table td { padding: 5px; }
+.highlight table pre { margin: 0; }
+
+.highlight, .highlight .w
+{
+  color: #24292f;
+  background-color: #f6f8fa;
+}
+
+.highlight .k, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kt, .highlight .kv { color: #cf222e; }
+.highlight .gr { color: #f6f8fa; }
+
+.highlight .gd
+{
+  color: #82071e;
+  background-color: #ffebe9;
+}
+
+.highlight .nb { color: #953800; }
+.highlight .nc { color: #953800; }
+.highlight .no { color: #953800; }
+.highlight .nn { color: #953800; }
+.highlight .sr { color: #116329; }
+.highlight .na { color: #116329; }
+.highlight .nt { color: #116329; }
+
+.highlight .gi
+{
+  color: #116329;
+  background-color: #dafbe1;
+}
+
+.highlight .ges
+{
+  font-weight: bold;
+  font-style: italic;
+}
+
+.highlight .kc { color: #0550ae; }
+.highlight .l, .highlight .ld, .highlight .m, .highlight .mb, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .il, .highlight .mo, .highlight .mx { color: #0550ae; }
+.highlight .sb { color: #0550ae; }
+.highlight .bp { color: #0550ae; }
+.highlight .ne { color: #0550ae; }
+.highlight .nl { color: #0550ae; }
+.highlight .py { color: #0550ae; }
+.highlight .nv, .highlight .vc, .highlight .vg, .highlight .vi, .highlight .vm { color: #0550ae; }
+.highlight .o, .highlight .ow { color: #0550ae; }
+
+.highlight .gh
+{
+  color: #0550ae;
+  font-weight: bold;
+}
+
+.highlight .gu
+{
+  color: #0550ae;
+  font-weight: bold;
+}
+
+.highlight .s, .highlight .sa, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .se, .highlight .sh, .highlight .sx, .highlight .s1, .highlight .ss { color: #0a3069; }
+.highlight .nd { color: #8250df; }
+.highlight .nf, .highlight .fm { color: #8250df; }
+
+.highlight .err
+{
+  color: #f6f8fa;
+  background-color: #82071e;
+}
+
+.highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cp, .highlight .cpf, .highlight .c1, .highlight .cs { color: #6e7781; }
+.highlight .gl { color: #6e7781; }
+.highlight .gt { color: #6e7781; }
+.highlight .ni { color: #24292f; }
+.highlight .si { color: #24292f; }
+
+.highlight .ge
+{
+  color: #24292f;
+  font-style: italic;
+}
+
+.highlight .gs
+{
+  color: #24292f;
+  font-weight: bold;
+}

--- a/Contents/Preview CSS/DefaultCSS_Markdown.css
+++ b/Contents/Preview CSS/DefaultCSS_Markdown.css
@@ -1,73 +1,73 @@
 body {
-	background-color: #fff;
-	color: #333;
-	font: 16px 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
-	word-wrap: break-word;
-	line-height: 1.6;
-	padding: 0 20px 20px 20px;
-	width: 722px;
+  background-color: #fff;
+  color: #333;
+  font: 16px 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
+  word-wrap: break-word;
+  line-height: 1.6;
+  padding: 0 20px 20px 20px;
+  width: 722px;
 }
 
 a {
-	color: #4183c4;
-	text-decoration: none;
+  color: #4183c4;
+  text-decoration: none;
 }
 
 a:hover {
-	text-decoration: underline;
+  text-decoration: underline;
 }
 
 p, blockquote, ul, ol, dl, table, pre {
-	margin: 15px 0;
+  margin: 15px 0;
 }
 
 ul, ol {
-	padding-left: 30px;
+  padding-left: 30px;
 }
 
 h1 {
-    padding-bottom: 0.3em;
-    font-size: 2.25em;
-    line-height: 1.2;
-    border-bottom: 1px solid #eee;
+  padding-bottom: 0.3em;
+  font-size: 2.25em;
+  line-height: 1.2;
+  border-bottom: 1px solid #eee;
 }
 
 h2 {
-	border-bottom: 1px solid #eee;
-	color: #000;
-	padding-bottom: 0.3em;
-    font-size: 1.75em;
-    line-height: 1.225;
+  border-bottom: 1px solid #eee;
+  color: #000;
+  padding-bottom: 0.3em;
+  font-size: 1.75em;
+  line-height: 1.225;
 }
 
 h3 {
-	font-size: 1.5em;
+  font-size: 1.5em;
 }
 
 h4 {
-	font-size: 1.2em;
+  font-size: 1.2em;
 }
 
 h5 {
-	font-size: 1.0em;
+      font-size: 1.0em;
 }
 
 h6 {
-	color: #777;
-	font-size: 1.0em;
+  color: #777;
+  font-size: 1.0em;
 }
 
 h1, h2, h3, h4, h5, h6 {
-	font-weight: bold;
-	margin: 1em 0 15px 0;
+  font-weight: bold;
+  margin: 1em 0 15px 0;
 }
 
 h1 + p, h2 + p, h3 + p {
-	margin-top: 10px;
+  margin-top: 10px;
 }
 
 img {
-	max-width: 100%;
+  max-width: 100%;
 }
 
 pre {
@@ -75,32 +75,32 @@ pre {
 }
 
 code {
-    font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
-    padding: 0.4em;
-    margin: 0;
-    font-size: 85%;
-    border-radius: 3px;
-    white-space: pre;
-    background-color: #f8f8f8;
+  font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  padding: 0.4em;
+  margin: 0;
+  font-size: 85%;
+  border-radius: 3px;
+  white-space: pre;
+  background-color: #f8f8f8;
 }
 
 pre code {
-	border-radius: 3px;
-	font-family: Consolas, "Liberation Mono", Courier, monospace;
-	font-size: 14px;
-	line-height: 1.4em;
-	margin: 0 2px;
+  border-radius: 3px;
+  font-family: Consolas, "Liberation Mono", Courier, monospace;
+  font-size: 14px;
+  line-height: 1.4em;
+  margin: 0 2px;
   padding: 16px;
-	white-space: pre;
-	display: block;
-	word-wrap: normal;
+  white-space: pre;
+  display: block;
+  word-wrap: normal;
 }
 
 
 blockquote {
-    padding: 0 1em;
-    color: #59636E;
-    border-left: .25em solid #D0D9E0;
+  padding: 0 1em;
+  color: #59636E;
+  border-left: .25em solid #D0D9E0;
 }
 
 blockquote > :first-child {
@@ -112,30 +112,30 @@ blockquote > :last-child {
 }
 
 table {
-    display: table;
-    width: 100%;
-    overflow: auto;
-    word-break: normal;
-    border-collapse: collapse;
-    margin-top: 0;
-    margin-bottom: 16px;
+  display: table;
+  width: 100%;
+  overflow: auto;
+  word-break: normal;
+  border-collapse: collapse;
+  margin-top: 0;
+  margin-bottom: 16px;
 }
 
 table tr {
-    background-color: #fff;
-    border-top: 1px solid #ccc;
+  background-color: #fff;
+  border-top: 1px solid #ccc;
 }
 
 table tr:nth-child(2n) {
-    background-color: #f8f8f8;
+  background-color: #f8f8f8;
 }
 
 table th, table td {
-    padding: 6px;
-    border: 1px solid #ddd;
-    display: table-cell;
+  padding: 6px;
+  border: 1px solid #ddd;
+  display: table-cell;
 }
 
 table th {
-    font-weight: bold;
+  font-weight: bold;
 }

--- a/Contents/Preview CSS/DefaultCSS_Markdown.css
+++ b/Contents/Preview CSS/DefaultCSS_Markdown.css
@@ -66,21 +66,12 @@ h1 + p, h2 + p, h3 + p {
 	margin-top: 10px;
 }
 
-pre {
-    overflow: auto;
-	background-color: #f8f8f8;
+img {
+	max-width: 100%;
 }
 
-pre code {
-	border-radius: 3px;
-	font-family: Consolas, "Liberation Mono", Courier, monospace;
-	font-size: 14px;
-	line-height: 1.4em;
-	margin: 0 2px;
-    padding: 16px;
-	white-space: pre;
-	display: block;
-	word-wrap: normal;
+pre {
+  overflow: auto;
 }
 
 code {
@@ -90,7 +81,21 @@ code {
     font-size: 85%;
     border-radius: 3px;
     white-space: pre;
+    background-color: #f8f8f8;
 }
+
+pre code {
+	border-radius: 3px;
+	font-family: Consolas, "Liberation Mono", Courier, monospace;
+	font-size: 14px;
+	line-height: 1.4em;
+	margin: 0 2px;
+  padding: 16px;
+	white-space: pre;
+	display: block;
+	word-wrap: normal;
+}
+
 
 blockquote {
     padding: 0 1em;

--- a/Contents/Preview CSS/DefaultCSS_Markdown.css
+++ b/Contents/Preview CSS/DefaultCSS_Markdown.css
@@ -1,143 +1,143 @@
 body {
-  background-color: #fff;
-  color: #333;
-  font: 16px 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
-  word-wrap: break-word;
-  line-height: 1.6;
-  padding: 0 20px 20px 20px;
-  width: 722px;
+    background-color: #fff;
+    color: #333;
+    font: 16px 'Helvetica Neue', Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
+    word-wrap: break-word;
+    line-height: 1.6;
+    padding: 0 20px 20px 20px;
+    width: 722px;
 }
 
 a {
-  color: #4183c4;
-  text-decoration: none;
+    color: #4183c4;
+    text-decoration: none;
 }
 
 a:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 
 p, blockquote, ul, ol, dl, table, pre {
-  margin: 15px 0;
+    margin: 15px 0;
 }
 
 ul, ol {
-  padding-left: 30px;
+    padding-left: 30px;
 }
 
 h1 {
-  padding-bottom: 0.3em;
-  font-size: 2.25em;
-  line-height: 1.2;
-  border-bottom: 1px solid #eee;
+    padding-bottom: 0.3em;
+    font-size: 2.25em;
+    line-height: 1.2;
+    border-bottom: 1px solid #eee;
 }
 
 h2 {
-  border-bottom: 1px solid #eee;
-  color: #000;
-  padding-bottom: 0.3em;
-  font-size: 1.75em;
-  line-height: 1.225;
+    border-bottom: 1px solid #eee;
+    color: #000;
+    padding-bottom: 0.3em;
+    font-size: 1.75em;
+    line-height: 1.225;
 }
 
 h3 {
-  font-size: 1.5em;
+    font-size: 1.5em;
 }
 
 h4 {
-  font-size: 1.2em;
+    font-size: 1.2em;
 }
 
 h5 {
-      font-size: 1.0em;
+            font-size: 1.0em;
 }
 
 h6 {
-  color: #777;
-  font-size: 1.0em;
+    color: #777;
+    font-size: 1.0em;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-weight: bold;
-  margin: 1em 0 15px 0;
+    font-weight: bold;
+    margin: 1em 0 15px 0;
 }
 
 h1 + p, h2 + p, h3 + p {
-  margin-top: 10px;
+    margin-top: 10px;
 }
 
 img {
-  max-width: 100%;
+    max-width: 100%;
 }
 
 pre {
-  overflow: auto;
+    overflow: auto;
 }
 
 code {
-  font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
-  padding: 0.4em;
-  margin: 0;
-  font-size: 85%;
-  border-radius: 3px;
-  white-space: pre;
-  background-color: #f8f8f8;
+    font: 12px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    padding: 0.4em;
+    margin: 0;
+    font-size: 85%;
+    border-radius: 3px;
+    white-space: pre;
+    background-color: #f8f8f8;
 }
 
 pre code {
-  border-radius: 3px;
-  font-family: Consolas, "Liberation Mono", Courier, monospace;
-  font-size: 14px;
-  line-height: 1.4em;
-  margin: 0 2px;
-  padding: 16px;
-  white-space: pre;
-  display: block;
-  word-wrap: normal;
+    border-radius: 3px;
+    font-family: Consolas, "Liberation Mono", Courier, monospace;
+    font-size: 14px;
+    line-height: 1.4em;
+    margin: 0 2px;
+    padding: 16px;
+    white-space: pre;
+    display: block;
+    word-wrap: normal;
 }
 
 
 blockquote {
-  padding: 0 1em;
-  color: #59636E;
-  border-left: .25em solid #D0D9E0;
+    padding: 0 1em;
+    color: #59636E;
+    border-left: .25em solid #D0D9E0;
 }
 
 blockquote > :first-child {
-    margin-top:0
+        margin-top:0
 }
 
 blockquote > :last-child {
-    margin-bottom:0
+        margin-bottom:0
 }
 
 table {
-  display: table;
-  width: 100%;
-  overflow: auto;
-  word-break: normal;
-  border-collapse: collapse;
-  margin-top: 0;
-  margin-bottom: 16px;
+    display: table;
+    width: 100%;
+    overflow: auto;
+    word-break: normal;
+    border-collapse: collapse;
+    margin-top: 0;
+    margin-bottom: 16px;
 }
 
 table tr {
-  background-color: #fff;
-  border-top: 1px solid #ccc;
+    background-color: #fff;
+    border-top: 1px solid #ccc;
 }
 
 table tr:nth-child(2n) {
-  background-color: #f8f8f8;
+    background-color: #f8f8f8;
 }
 
 table th, table td {
-  padding: 6px;
-  border: 1px solid #ddd;
-  display: table-cell;
+    padding: 6px;
+    border: 1px solid #ddd;
+    display: table-cell;
 }
 
 table th {
-  font-weight: bold;
+    font-weight: bold;
 }
 
 /* Syntax Highlighting */
@@ -147,8 +147,8 @@ table th {
 
 .highlight, .highlight .w
 {
-  color: #24292f;
-  background-color: #f6f8fa;
+    color: #24292f;
+    background-color: #f6f8fa;
 }
 
 .highlight .k, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kt, .highlight .kv { color: #cf222e; }
@@ -156,8 +156,8 @@ table th {
 
 .highlight .gd
 {
-  color: #82071e;
-  background-color: #ffebe9;
+    color: #82071e;
+    background-color: #ffebe9;
 }
 
 .highlight .nb { color: #953800; }
@@ -170,14 +170,14 @@ table th {
 
 .highlight .gi
 {
-  color: #116329;
-  background-color: #dafbe1;
+    color: #116329;
+    background-color: #dafbe1;
 }
 
 .highlight .ges
 {
-  font-weight: bold;
-  font-style: italic;
+    font-weight: bold;
+    font-style: italic;
 }
 
 .highlight .kc { color: #0550ae; }
@@ -192,14 +192,14 @@ table th {
 
 .highlight .gh
 {
-  color: #0550ae;
-  font-weight: bold;
+    color: #0550ae;
+    font-weight: bold;
 }
 
 .highlight .gu
 {
-  color: #0550ae;
-  font-weight: bold;
+    color: #0550ae;
+    font-weight: bold;
 }
 
 .highlight .s, .highlight .sa, .highlight .sc, .highlight .dl, .highlight .sd, .highlight .s2, .highlight .se, .highlight .sh, .highlight .sx, .highlight .s1, .highlight .ss { color: #0a3069; }
@@ -208,8 +208,8 @@ table th {
 
 .highlight .err
 {
-  color: #f6f8fa;
-  background-color: #82071e;
+    color: #f6f8fa;
+    background-color: #82071e;
 }
 
 .highlight .c, .highlight .ch, .highlight .cd, .highlight .cm, .highlight .cp, .highlight .cpf, .highlight .c1, .highlight .cs { color: #6e7781; }
@@ -220,12 +220,12 @@ table th {
 
 .highlight .ge
 {
-  color: #24292f;
-  font-style: italic;
+    color: #24292f;
+    font-style: italic;
 }
 
 .highlight .gs
 {
-  color: #24292f;
-  font-weight: bold;
+    color: #24292f;
+    font-weight: bold;
 }

--- a/Contents/Preview Filters/DefaultFilter_Markdown.rb
+++ b/Contents/Preview Filters/DefaultFilter_Markdown.rb
@@ -1,8 +1,17 @@
 #!/usr/bin/env ruby
 
 require 'redcarpet'
+require 'rouge'
+require 'rouge/plugins/redcarpet'
 
-r = Redcarpet::Markdown.new(Redcarpet::Render::HTML, 
+class MarkdownHighlightRender < Redcarpet::Render::HTML
+ def initialize(extensions = {})
+	 super extensions.merge(link_attributes: { target: '_blank' })
+ end
+ include Rouge::Plugins::Redcarpet
+end
+
+r = Redcarpet::Markdown.new(MarkdownHighlightRender, 
   :autolink => true,
   :space_after_headers => true,
   :fenced_code_blocks => true,
@@ -13,6 +22,3 @@ r = Redcarpet::Markdown.new(Redcarpet::Render::HTML,
   :tables => true)
 
 input = ARGF.read
-
-puts r.render(input)
-

--- a/Contents/Preview Filters/DefaultFilter_Markdown.rb
+++ b/Contents/Preview Filters/DefaultFilter_Markdown.rb
@@ -3,35 +3,35 @@
 require 'redcarpet'
 
 module Compatability
-	private
-	
-	def hightlighting?
-		require 'rouge'
-		require 'rouge/plugins/redcarpet'
-	rescue LoadError
-		false
-	end
+    private
+    
+    def hightlighting?
+        require 'rouge'
+        require 'rouge/plugins/redcarpet'
+    rescue LoadError
+        false
+    end
 end
 
 class SyntaxHighlightRenderer < Redcarpet::Render::HTML	
-	extend Compatability
-	include Rouge::Plugins::Redcarpet if hightlighting?
-	
-	def initialize(extensions = {})
-		super extensions.merge(link_attributes: { target: '_blank' })
-	end
+    extend Compatability
+    include Rouge::Plugins::Redcarpet if hightlighting?
+    
+    def initialize(extensions = {})
+        super extensions.merge(link_attributes: { target: '_blank' })
+    end
 end
 
 md_to_html = Redcarpet::Markdown.new(
-		SyntaxHighlightRenderer, 
-		:autolink => true,
-		:space_after_headers => true,
-		:fenced_code_blocks => true,
-		:disable_indented_code_blocks => true,
-		:no_intra_emphasis => true,
-		:lax_html_blocks => true,
-		:strikethrough =>true,
-		:tables => true
+    SyntaxHighlightRenderer, 
+    :autolink => true,
+    :space_after_headers => true,
+    :fenced_code_blocks => true,
+    :disable_indented_code_blocks => true,
+    :no_intra_emphasis => true,
+    :lax_html_blocks => true,
+    :strikethrough =>true,
+    :tables => true
   )
 
 input_markdown = ARGF.read

--- a/Contents/Preview Filters/DefaultFilter_Markdown.rb
+++ b/Contents/Preview Filters/DefaultFilter_Markdown.rb
@@ -1,24 +1,39 @@
 #!/usr/bin/env ruby
 
 require 'redcarpet'
-require 'rouge'
-require 'rouge/plugins/redcarpet'
 
-class MarkdownHighlightRender < Redcarpet::Render::HTML
- def initialize(extensions = {})
-	 super extensions.merge(link_attributes: { target: '_blank' })
- end
- include Rouge::Plugins::Redcarpet
+module Compatability
+	private
+	
+	def hightlighting?
+		require 'rouge'
+		require 'rouge/plugins/redcarpet'
+	rescue LoadError
+		false
+	end
 end
 
-r = Redcarpet::Markdown.new(MarkdownHighlightRender, 
-  :autolink => true,
-  :space_after_headers => true,
-  :fenced_code_blocks => true,
-  :disable_indented_code_blocks => true,
-  :no_intra_emphasis => true,
-  :lax_html_blocks => true,
-  :strikethrough =>true,
-  :tables => true)
+class SyntaxHighlightRenderer < Redcarpet::Render::HTML	
+	extend Compatability
+	include Rouge::Plugins::Redcarpet if hightlighting?
+	
+	def initialize(extensions = {})
+		super extensions.merge(link_attributes: { target: '_blank' })
+	end
+end
 
-input = ARGF.read
+md_to_html = Redcarpet::Markdown.new(
+		SyntaxHighlightRenderer, 
+		:autolink => true,
+		:space_after_headers => true,
+		:fenced_code_blocks => true,
+		:disable_indented_code_blocks => true,
+		:no_intra_emphasis => true,
+		:lax_html_blocks => true,
+		:strikethrough =>true,
+		:tables => true
+  )
+
+input_markdown = ARGF.read
+
+puts md_to_html.render(input_markdown)


### PR DESCRIPTION
- Tweaked the code block styles so the inline versions show a background. 
- Added an image style so images don't run off the page.
- Added syntax highlighting for code blocks if the rouge gem is installed, otherwise it should work as before.

I've been wanting to use Redcarpet in a personal project and this has been a pretty great experimental ground.

I would like to add support for github admonition blocks a.k.a. alerts.
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts

-- Have a good one